### PR TITLE
fix list of categories and spendings  for particular user

### DIFF
--- a/app/assets/stylesheets/popup_styles.css
+++ b/app/assets/stylesheets/popup_styles.css
@@ -71,4 +71,9 @@ input[type='radio'] {
     grid-template-columns: 1fr 1fr 1fr;
     gap: 1.5rem;
   }
+
+  .popup {
+    width: 50%;
+    margin: 5% auto;
+  }
 }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,8 +1,8 @@
 class CategoriesController < ApplicationController
   before_action :authenticate_user!
   def index
-    @categories = Category.all.includes(:spendings)
     @user = current_user
+    @categories = Category.where(user_id: @user.id).includes(:spendings)
   end
 
   def new

--- a/app/controllers/spendings_controller.rb
+++ b/app/controllers/spendings_controller.rb
@@ -1,7 +1,7 @@
 class SpendingsController < ApplicationController
   def new
     @user = current_user
-    @categories = Category.all
+    @categories = Category.where(user_id: @user.id)
     @category = Category.find(params[:category_id])
   end
 

--- a/app/javascript/controllers/categories_controller.js
+++ b/app/javascript/controllers/categories_controller.js
@@ -46,8 +46,8 @@ const createIconPopup = () => {
   cancelbutton.setAttribute('type', 'button');
   cancelbutton.textContent = 'Cancel';
   cancelbutton.onclick = () => dismisspopup();
-  popupBtnGroup.appendChild(okbutton);
   popupBtnGroup.appendChild(cancelbutton);
+  popupBtnGroup.appendChild(okbutton);
   popup.appendChild(popupBtnGroup);
   const errMsg = document.createElement('h5');
   errMsg.id='popup-err-msg';


### PR DESCRIPTION
In this PR, I made a hotfix for a bug.

-Earlier, the logged in user could see all categories and all spendings of other users. Now user can access only their own spendings
 